### PR TITLE
feat: use native `linear-gradient()`

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -133,7 +133,7 @@ const styles = StyleSheet.create({
     width: "300%",
     marginHorizontal: "-100%",
     [process.env.EXPO_OS === "web" ? "backgroundImage" : "experimental_backgroundImage"]:
-      "linear-gradient(90deg, #422006 46%, #facc15 50%, #422006 54%)",
+      "linear-gradient(100deg, #422006 46%, #facc15 50%, #422006 54%)",
   },
   label: {
     color: "#422006",

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,4 @@
 import MaskedView from "@react-native-masked-view/masked-view";
-import { LinearGradient } from "expo-linear-gradient";
 import { StyleSheet, View } from "react-native";
 import Animated, { cubicBezier } from "react-native-reanimated";
 
@@ -26,7 +25,7 @@ export default function App() {
         >
           <Animated.View
             style={[
-              styles.gradientContainer,
+              styles.gradient,
               {
                 animationName: {
                   from: {
@@ -41,15 +40,7 @@ export default function App() {
                 animationTimingFunction: "linear",
               },
             ]}
-          >
-            <LinearGradient
-              colors={["#422006", "#facc15", "#422006"]}
-              locations={[0.46, 0.5, 0.54]}
-              start={{ x: 0, y: -3 }}
-              end={{ x: 1, y: 3 }}
-              style={styles.gradient}
-            />
-          </Animated.View>
+          />
         </MaskedView>
       </View>
       <View style={styles.starWrapper}>
@@ -137,14 +128,12 @@ const styles = StyleSheet.create({
     height: 60,
     width: 235,
   },
-  gradientContainer: {
+  gradient: {
     flex: 1,
     width: "300%",
     marginHorizontal: "-100%",
-  },
-  gradient: {
-    flex: 1,
-    width: "100%",
+    [process.env.EXPO_OS === "web" ? "backgroundImage" : "experimental_backgroundImage"]:
+      "linear-gradient(90deg, #422006 46%, #facc15 50%, #422006 54%)",
   },
   label: {
     color: "#422006",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "expo-constants": "~17.0.4",
         "expo-font": "~13.0.3",
         "expo-haptics": "~14.0.1",
-        "expo-linear-gradient": "^14.0.2",
         "expo-linking": "~7.0.4",
         "expo-router": "~4.0.17",
         "expo-splash-screen": "~0.29.21",
@@ -6476,16 +6475,6 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
-      }
-    },
-    "node_modules/expo-linear-gradient": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-14.0.2.tgz",
-      "integrity": "sha512-nvac1sPUfFFJ4mY25UkvubpUV/olrBH+uQw5k+beqSvQaVQiUfFtYzfRr+6HhYBNb4AEsOtpsCRkpDww3M2iGQ==",
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/expo-linking": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,12 +29,12 @@
         "react-dom": "18.3.1",
         "react-native": "~0.77.0",
         "react-native-css-animations": "^0.1.1",
-        "react-native-gesture-handler": "^2.22.0",
+        "react-native-gesture-handler": "~2.22.0",
         "react-native-reanimated": "^4.0.0-beta.1",
-        "react-native-safe-area-context": "4.12.0",
-        "react-native-screens": "~4.4.0",
+        "react-native-safe-area-context": "~5.1.0",
+        "react-native-screens": "~4.5.0",
         "react-native-web": "~0.19.13",
-        "react-native-webview": "13.12.5"
+        "react-native-webview": "~13.13.1"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -11432,9 +11432,9 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "4.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.0.0-beta.1.tgz",
-      "integrity": "sha512-ciXrm0J4gmRaKqLVHDwtts+CIAFiqEve8ficdLj21jdnWia6JELS/YuJVC+IEy7TO+4+5vaL4WYYppGrC8w26w==",
+      "version": "4.0.0-nightly-20250126-bfc3cfbf5",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.0.0-nightly-20250126-bfc3cfbf5.tgz",
+      "integrity": "sha512-nT9gItcTvbWrD1xVC5875nqxh9bGVFE7UJVlXz2h+JPFSR6nM/8eINkc+jel/jSh5yodj6DDrfe4LvIb536Wgg==",
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -11455,18 +11455,18 @@
       }
     },
     "node_modules/react-native-safe-area-context": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.12.0.tgz",
-      "integrity": "sha512-ukk5PxcF4p3yu6qMZcmeiZgowhb5AsKRnil54YFUUAXVIS7PJcMHGGC+q44fCiBg44/1AJk5njGMez1m9H0BVQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.1.0.tgz",
+      "integrity": "sha512-Y4vyJX+0HPJUQNVeIJTj2/UOjbSJcB09OEwirAWDrOZ67Lz5p43AmjxSy8nnZft1rMzoh3rcPuonB6jJyHTfCw==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
       }
     },
     "node_modules/react-native-screens": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.4.0.tgz",
-      "integrity": "sha512-c7zc7Zwjty6/pGyuuvh9gK3YBYqHPOxrhXfG1lF4gHlojQSmIx2piNbNaV+Uykj+RDTmFXK0e/hA+fucw/Qozg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.5.0.tgz",
+      "integrity": "sha512-yBWeN5EHNeew9f0ia9VE7JSlUQzCZEwkb87r7A7/Sg41OJHuRKHNRhmdCOiMBUqwwQi3F+b4NZGywjeM/gWMyg==",
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
@@ -11506,9 +11506,9 @@
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
     },
     "node_modules/react-native-webview": {
-      "version": "13.12.5",
-      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.12.5.tgz",
-      "integrity": "sha512-INOKPom4dFyzkbxbkuQNfeRG9/iYnyRDzrDkJeyvSWgJAW2IDdJkWFJBS2v0RxIL4gqLgHkiIZDOfiLaNnw83Q==",
+      "version": "13.13.1",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.13.1.tgz",
+      "integrity": "sha512-Qwrvdwl2U2bG8QlghfRzGR/PCwKzW/cXTCR/WfMWHeGoADp2CHuCaEpfYO/HhlLLGy3Jqizsy+sjFhnKa1AgrA==",
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
         "invariant": "2.2.4"

--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
     "react-dom": "18.3.1",
     "react-native": "~0.77.0",
     "react-native-css-animations": "^0.1.1",
-    "react-native-gesture-handler": "^2.22.0",
+    "react-native-gesture-handler": "~2.22.0",
     "react-native-reanimated": "^4.0.0-beta.1",
-    "react-native-safe-area-context": "4.12.0",
-    "react-native-screens": "~4.4.0",
+    "react-native-safe-area-context": "~5.1.0",
+    "react-native-screens": "~4.5.0",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.5"
+    "react-native-webview": "~13.13.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
@@ -59,7 +59,10 @@
       "exclude": [
         "react-native@~0.77.0",
         "react-native-reanimated@^4.0.0-beta.1",
-        "react-native-gesture-handler@~2.22.0"
+        "react-native-gesture-handler@~2.22.0",
+        "react-native-screens@~4.5.0",
+        "react-native-safe-area-context@~5.1.0",
+        "react-native-webview@~13.12.5"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "expo-constants": "~17.0.4",
     "expo-font": "~13.0.3",
     "expo-haptics": "~14.0.1",
-    "expo-linear-gradient": "^14.0.2",
     "expo-linking": "~7.0.4",
     "expo-router": "~4.0.17",
     "expo-splash-screen": "~0.29.21",


### PR DESCRIPTION
I learned that in React Native soon there will be a native linear-gradient() implementation. This PR explores this functionality.

I'm happy to announce that it works perfectly on React Native 0.77 🔥


https://github.com/user-attachments/assets/c3e4b422-8413-4844-af1c-3032c19e6f47


